### PR TITLE
support locale languages

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -89,7 +89,7 @@ gtk_req_version = '>= 3.0.0'
 gtk_deps = dependency('gtk+-3.0', version: gtk_req_version)
 pwquality_deps = dependency('pwquality')
 act_deps = dependency('accountsservice')
-#gd_deps = dependency('gnome-desktop-3.0')
+md_deps = dependency('mate-desktop-2.0')
 crypt_deps = cc.find_library('crypt', required: true)
 
 # Configure data

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,13 @@
 #include "user-face.h"
 #include "user-list.h"
 
+static gboolean on_window_quit (GtkWidget *widget, GdkEvent *event, gpointer user_data)
+{
+	g_strfreev(all_languages);
+	gtk_main_quit();
+	return TRUE;
+}
+
 static void InitMainWindow(UserAdmin *ua)
 {
     GtkWidget *Window;
@@ -14,9 +21,11 @@ static void InitMainWindow(UserAdmin *ua)
     gtk_window_set_position(GTK_WINDOW(Window), GTK_WIN_POS_CENTER);
     gtk_window_set_title(GTK_WINDOW(Window), _("Mate User Manage"));
     gtk_container_set_border_width(GTK_CONTAINER(Window),10);
+    g_signal_connect(G_OBJECT(Window), "delete-event", G_CALLBACK(on_window_quit), NULL);
 
     ua->MainWindow = Window;
-}  
+}
+
 static void CreateInterface(GtkWidget *Vbox,UserAdmin *ua)
 {
     GtkWidget *Hbox;
@@ -54,6 +63,7 @@ int main(int argc, char **argv)
     
     gtk_init(&argc, &argv);
     
+    all_languages = mate_get_all_locales ();
     InitMainWindow(&ua);
 
     WindowLogin = ua.MainWindow;

--- a/src/meson.build
+++ b/src/meson.build
@@ -27,7 +27,7 @@ account_user_src = gnome.gdbus_codegen(
 
 executable('user-admin',
   sources : sources,
-  dependencies : [gtk_deps, pwquality_deps, act_deps, crypt_deps],
+  dependencies : [gtk_deps, pwquality_deps, act_deps, crypt_deps, md_deps],
   include_directories: top_srcdir,
   install : true,
   install_dir : get_option('bindir')

--- a/src/user-admin.c
+++ b/src/user-admin.c
@@ -272,9 +272,9 @@ static void NewUserSelectLanguage(GtkWidget *widget,gpointer data)
 static int WriteUserInfo(int index,UserAdmin *ua)
 {
 	ActUserManager *Manager;
-    GError *error;
+    GError *error = NULL;
     ActUser *user;
-    error = NULL;
+    gint lang_index;
 
     Manager = act_user_manager_get_default ();
     user = act_user_manager_create_user(Manager,
@@ -292,10 +292,9 @@ static int WriteUserInfo(int index,UserAdmin *ua)
     {        
         act_user_set_account_type(user,ACT_USER_ACCOUNT_TYPE_ADMINISTRATOR);
     }    
-    if(ua->ul[index].LangType == ENGLIST)
-        act_user_set_language(user,"en_US.UTF-8");
-    else
-        act_user_set_language(user,"zh_CN.UTF-8");
+
+    lang_index = ua->ul[index].LangType;
+    act_user_set_language(user, all_languages[lang_index]);
     
     if(ua->ul[index].PasswordType == NEWPASS)
     {
@@ -392,7 +391,7 @@ static void InitNewUser(UserAdmin *ua)
     memset(ua->ul[NewUserIndex].UserIcon,'\0',sizeof(ua->ul[NewUserIndex].UserIcon));
     memcpy(ua->ul[NewUserIndex].UserIcon,DEFAULT,strlen(DEFAULT));
     ua->ul[NewUserIndex].UserType = STANDARD;
-    ua->ul[NewUserIndex].LangType = CHINSE;
+    ua->ul[NewUserIndex].LangType = 0;
     ua->ul[NewUserIndex].PasswordType = NEWPASS;
     memset(ua->ul[NewUserIndex].PassText,'\0',sizeof(ua->ul[NewUserIndex].PassText));
     memcpy(ua->ul[NewUserIndex].PassText,s,strlen(s));
@@ -501,8 +500,8 @@ static void GetNewUserInfo(GtkWidget *Vbox,UserAdmin *ua)
     SetLableFontType(LabelLanguageType,"gray",11,_("Language"));
     gtk_grid_attach(GTK_GRID(Table) ,LabelLanguageType , 0 , 4 , 1 , 1);        
 
-    NewLanguage = SetComboLanguageType(_("Chinese"),_("English"));
-    gtk_combo_box_set_active(GTK_COMBO_BOX(NewLanguage),CHINSE);
+    NewLanguage = SetComboLanguageType();
+    gtk_combo_box_set_active(GTK_COMBO_BOX(NewLanguage), 0);
     ua->NewUserLangType = NewLanguage;
     g_signal_connect(G_OBJECT(NewLanguage),
                     "changed",

--- a/src/user-base.c
+++ b/src/user-base.c
@@ -175,7 +175,7 @@ void DisplayUserSetOther(GtkWidget *Hbox,UserAdmin *ua)
     SetLableFontType(LabelLanguage,"gray",11,_("Language"));
     gtk_grid_attach(GTK_GRID(table) , LabelLanguage , 0 , 1 , 1 , 1);
 
-    ComboLanguage = SetComboLanguageType(_("Chinese"),_("English"));
+    ComboLanguage = SetComboLanguageType();
     ua->ComUserLanguage = ComboLanguage;
     gtk_combo_box_set_active(GTK_COMBO_BOX(ComboLanguage),ua->ul[0].LangType);
     gtk_grid_attach(GTK_GRID(table) , ComboLanguage , 1 , 1 , 2 , 1);

--- a/src/user-info.c
+++ b/src/user-info.c
@@ -134,15 +134,19 @@ static const gchar *GetIconPath(ActUser *user)
 static int GetUserLang(ActUser *user)
 {
     const gchar *Lang = NULL;
+    guint i, len;
+
     Lang = act_user_get_language(user);
-    if(strcmp(Lang,"zh_CN.UTF-8")== 0)
-        return CHINSE;
-    else if(strcmp(Lang,"en_US.UTF-8") == 0)
-        return ENGLIST;
 
+    len = g_strv_length (all_languages);
+
+    for (i =0; i < len; i++) {
+	    if (g_ascii_strcasecmp(Lang, all_languages[i]) == 0)
+		    return i;
+    }
     return -1;
+}
 
-}        
 static int GetUserType(ActUser *user)
 {
     ActUserAccountType UserType;

--- a/src/user-share.c
+++ b/src/user-share.c
@@ -485,18 +485,24 @@ void OffNote(GtkWidget *label,UserAdmin *ua)
 *
 * 作者:  zhuyaliang  09/05/2018
 ******************************************************************************/
-GtkWidget *SetComboLanguageType(const char *s1,const char *s2)
+GtkWidget *SetComboLanguageType(void)
 {
     GtkListStore    *Store;
     GtkTreeIter     Iter;
     GtkCellRenderer *Renderer;
     GtkWidget *ComboUser;
+    char *lang;
+    guint i, len;
 
     Store = gtk_list_store_new(1,G_TYPE_STRING);
-    gtk_list_store_append(Store,&Iter);
-    gtk_list_store_set(Store,&Iter,0,s1,-1);
-    gtk_list_store_append(Store,&Iter);
-    gtk_list_store_set(Store,&Iter,0,s2,-1);
+
+    len = g_strv_length (all_languages);
+    for (i =0; i < len; i++) {
+	    lang = mate_get_language_from_locale (all_languages[i], NULL);
+	    gtk_list_store_append (Store, &Iter);
+	    gtk_list_store_set (Store, &Iter, 0, lang, -1);
+	    g_free(lang);
+    }
 
     ComboUser = gtk_combo_box_new_with_model(GTK_TREE_MODEL(Store));
     g_object_unref(G_OBJECT(Store));

--- a/src/user-share.h
+++ b/src/user-share.h
@@ -21,7 +21,7 @@ void UserListAppend(GtkWidget *list,
 GdkPixbuf *SetUserFaceSize(const char  *PicName, int Size);
 void OpenNote(GtkWidget *label,const char *note,UserAdmin *ua);
 void OffNote(GtkWidget *label,UserAdmin *ua);
-GtkWidget *SetComboLanguageType(const char *s1,const char *s2);
+GtkWidget *SetComboLanguageType(void);
 GtkWidget *SetComboUserType(const char *s1,const char *s2);
 void UpdateInterface(int Cnt,UserAdmin *ua);
 gboolean CheckPassword(gpointer data);

--- a/src/user.h
+++ b/src/user.h
@@ -10,8 +10,8 @@
 #include <unistd.h>
 #include <time.h>
 #include <sys/time.h>
-#define GNOME_DESKTOP_USE_UNSTABLE_API
-#include <gnome-desktop-3.0/libgnome-desktop/gnome-languages.h>
+#define MATE_DESKTOP_USE_UNSTABLE_API
+#include <libmate-desktop/mate-languages.h>
 
 #include <accountsservice-1.0/act/act-user-manager.h>
 #include <accountsservice-1.0/act/act-user.h>
@@ -22,9 +22,6 @@
 #define  NUMMAX    20
 #define  PICMAX    20    
 #define  NONE      3
-#define  ENGLIST   1
-#define  CHINSE    0
-
 
 #define  OLDPASS   0
 #define  NEWPASS   1
@@ -100,5 +97,6 @@ static const char StandardCharacter[] = {"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKL
 int gnCnt;                //计数
 int gnCurrentUserIndex;   //代表当前用户标号
 GtkWidget *WindowLogin;          //首页窗口
+char **all_languages;
 
 #endif


### PR DESCRIPTION
Support language from `locale -a`, and require mate-desktop now.