### PR TITLE
Fix some typos in translation strings

### DIFF
--- a/src/user-admin.c
+++ b/src/user-admin.c
@@ -165,7 +165,7 @@ static gboolean UserNameValidCheck (const gchar *UserName, gchar **Message)
     }
     else 
     {
-        *Message = g_strdup (_("This will be used to name your home folder and cant be changed."));
+        *Message = g_strdup (_("This will be used to name your home folder and can't be changed."));
     }
 
     return valid;

--- a/src/user-base.c
+++ b/src/user-base.c
@@ -184,7 +184,7 @@ void DisplayUserSetOther(GtkWidget *Hbox,UserAdmin *ua)
     ua->ComUserLanguage = ComboLanguage;
     index = GetCurrentLangIndex(ua->ul[0].LangName);
     if(index < 0)
-        MessageReport(_("Get user lang"),_("get user lang fali"),ERROR);
+        MessageReport(_("Get user language"),_("get user language failed"),ERROR);
     gtk_combo_box_set_active(GTK_COMBO_BOX(ComboLanguage),index);
     gtk_grid_attach(GTK_GRID(table) , ComboLanguage , 1 , 1 , 2 , 1);
     g_signal_connect(G_OBJECT(ComboLanguage),

--- a/src/user-info.c
+++ b/src/user-info.c
@@ -233,7 +233,7 @@ static void UserAdded(ActUser *user,int index,UserAdmin *ua)
     LangName = GetUserLang(user);
     if(strlen(LangName) <= 0)
     {
-        sprintf(Msg,"%s %s",ua->ul[index].UserName,_("Get languages faild"));
+        sprintf(Msg,"%s %s",ua->ul[index].UserName,_("Get languages failed"));
         MessageReport(_("Get user languages"),Msg,ERROR); 
     }
     memset(ua->ul[index].LangName,'\0',sizeof(ua->ul[index].LangName));

--- a/src/user-share.c
+++ b/src/user-share.c
@@ -311,11 +311,11 @@ static const gchar *pw_error_hint (gint error)
         case PWQ_ERROR_MAX_CONSECUTIVE:
                 return _("Try to avoid repeating the same character");
         case PWQ_ERROR_MAX_CLASS_REPEAT:
-                return _("Try to avoid repeating the same type of character: you need     to mix up letters, numbers and punctuation.");
+                return _("Try to avoid repeating the same type of character: you need to mix up letters, numbers and punctuation.");
         case PWQ_ERROR_MAX_SEQUENCE:
                 return _("Try to avoid sequences like 1234 or abcd");
         case PWQ_ERROR_MIN_LENGTH:
-                return _("Password length needs more than 8 bits. Add more letters,\n umbers and punctuation");
+                return _("Password length needs more than 8 bits. Add more letters, numbers and punctuation");
         case PWQ_ERROR_EMPTY_PASSWORD:
                 return ("     ");
         default:


### PR DESCRIPTION
I started with a  translation for german language and stumbled about those typos.

There is one issue left.
Creating `de.po` with
`msginit --locale=de --input=user-admin.pot`
gives me this warning, but i don#t know how to handle this.
```
user-admin.pot:178: warning: internationalized messages should not contain the '\r' escape sequence
```
I think `\r\n` can be removed here?
A new line will created automatic with the command above?