### PR TITLE
Improve integration into MATE environment

### DIFF
--- a/data/mate-user-admin.desktop.in
+++ b/data/mate-user-admin.desktop.in
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=MATE User Manager
+Name=Users Management
 Name[ca]=Gestor d'usuaris de MATE
 Name[zh_CN]=用户管理
-Comment=Manage User 
+Comment=Manage Users
 Comment[ca]=Gestioneu els usuaris
 Comment[zh_CN]=管理用户权限、语言、密码、登录名称、头像。
 Categories=GTK;Settings;System;Utility;

--- a/po/ca.po
+++ b/po/ca.po
@@ -23,7 +23,7 @@ msgid "Get Icon Fail"
 msgstr "Ha fallat l'obtenció de la icona"
 
 #: src/main.c:48
-msgid "Mate User Manage"
+msgid "Users Management"
 msgstr "Gestió d'usuaris de MATE"
 
 #: src/main.c:102 src/main.c:144
@@ -282,7 +282,7 @@ msgid "User List"
 msgstr "Llista d'usuaris"
 
 #: src/user-list.c:202
-msgid "Close Quit"
+msgid "Close"
 msgstr "Tanca i surt"
 
 #: src/user-share.c:111

--- a/po/de.po
+++ b/po/de.po
@@ -22,7 +22,7 @@ msgid "Get Icon Fail"
 msgstr "Symbolfehler erhalten"
 
 #: src/main.c:48
-msgid "Mate User Manage"
+msgid "Users Management"
 msgstr "Mate Benutzer Verwaltung"
 
 #: src/main.c:102 src/main.c:144
@@ -281,7 +281,7 @@ msgid "User List"
 msgstr "Benutzerliste"
 
 #: src/user-list.c:202
-msgid "Close Quit"
+msgid "Close"
 msgstr "Beenden"
 
 #: src/user-share.c:111

--- a/po/mate-user-admin.pot
+++ b/po/mate-user-admin.pot
@@ -22,7 +22,7 @@ msgid "Get Icon Fail"
 msgstr ""
 
 #: src/main.c:48
-msgid "Mate User Manage"
+msgid "Users Management"
 msgstr ""
 
 #: src/main.c:102 src/main.c:144
@@ -274,7 +274,7 @@ msgid "User List"
 msgstr ""
 
 #: src/user-list.c:202
-msgid "Close Quit"
+msgid "Close"
 msgstr ""
 
 #: src/user-share.c:111

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -24,7 +24,7 @@ msgid "Get Icon Fail"
 msgstr "获取图标失败"
 
 #: src/main.c:48
-msgid "Mate User Manage"
+msgid "Users Management"
 msgstr "Mate 用户管理"
 
 #: src/main.c:102 src/main.c:144
@@ -276,7 +276,7 @@ msgid "User List"
 msgstr "用户列表"
 
 #: src/user-list.c:202
-msgid "Close Quit"
+msgid "Close"
 msgstr "关闭退出"
 
 #: src/user-share.c:111


### PR DESCRIPTION
I think the following little changes would make the application better integrated into the MATE desktop environment, so I submit this proposal.

---

When you look in the control center, no MATE application name start with MATE (apart from MATE Tweak), so I propose to name it "User Management" (also I am not sure that "User Manage" sounds very well in English)
I also propose to rename the button "Close Quit" into "Close" to get consistent with the official MATE applications.

PS: Sorry but I can't update the translations in the `.po` files.

Signed-off-by: Pierre-Yves <pyu@riseup.net>