### PR TITLE
initial deb-package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,16 @@ Now there are accountservice DBUS services, which provide many user management r
 meson build -Dprefix=/usr
 ninja -C build
 sudo ninja -C build install
+```
 
+## Create deb package on Ubuntu MATE 22.04 LTS
 
+Note: you have to build and install deb-package of *group-service* first, then run below commands.
+
+```
+sudo apt-get update
+sudo apt-get install dpkg-dev debhelper-compat meson cmake pkg-config libgtk-3-dev libpwquality-dev libaccountsservice-dev libmate-desktop-dev
+
+dpkg-buildpackage -uc -us
+sudo apt-get install ../user-admin*.deb
+```

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+user-admin (1.6.0-1) jammy; urgency=medium
+
+  * Initial release
+
+ -- N0rbert <nrbrtx@gmail.com>  Fri, 20 May 2022 00:09:59 +0300

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,29 @@
+Source: user-admin
+Section: utils
+Priority: optional
+Maintainer: N0rbert <nrbrtx@gmail.com>
+Depends: group-service,
+         accountsservice,
+         libpwquality1,
+         mate-desktop-common
+Build-Depends: debhelper-compat (= 13),
+               meson (>= 0.53.0),
+               cmake,
+               pkg-config,
+               libgtk-3-dev,
+               libpwquality-dev,
+               libaccountsservice-dev,
+               group-service,
+               libmate-desktop-dev
+Standards-Version: 4.6.0
+Homepage: https://github.com/zhuyaliang/user-admin
+
+Package: user-admin
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: MATE User Manager
+ Using Dbus to manage user groups, you can complete the addition 
+ and deletion of user groups, add \ remove users to groups, and 
+ change the name of user groups.The `test` directory is some 
+ testing process.
+ 

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,11 @@
+#! /usr/bin/make -f
+
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,-O1 -Wl,-z,defs
+
+%:
+	dh $@
+	
+override_dh_auto_test:
+	DEB_BUILD_OPTIONS=nocheck dh_auto_test
+


### PR DESCRIPTION
This is the fix for https://github.com/zhuyaliang/user-admin/issues/49 .
You are welcome to change changelog text, maintainer's name and package description.
Currently the package builds normally on Ubuntu MATE 22.04 LTS and interacts with group-service as it should.