### PR TITLE
Dark mode compatibility: Don't force black font face on text labels

### DIFF
--- a/src/user-group-window.c
+++ b/src/user-group-window.c
@@ -654,7 +654,7 @@ static GtkWidget *load_create_group (UserGroupWindow *win)
     gtk_box_pack_start (GTK_BOX (vbox1), Scrolled, TRUE, TRUE, 0);
 
     label = gtk_label_new (NULL);
-    SetLableFontType(label, "black", 12, _("Please select the user to add to the new group"), FALSE);
+    SetLableFontType(label, NULL, 12, _("Please select the user to add to the new group"), FALSE);
     gtk_grid_attach (GTK_GRID (table), label, 0, 1, 2, 1);
 
     model = create_tree_model ();

--- a/src/user-share.c
+++ b/src/user-share.c
@@ -217,9 +217,18 @@ void SetLableFontType(GtkWidget  *Lable ,
 
     if (Color == NULL)
     {
-        LableTypeBuf = g_strdup_printf ("<span weight=\'light\'font_desc=\'%d\'><b>%s</b></span>",
-                         FontSzie,
-                         Word);
+        if(Blod)
+        {
+            LableTypeBuf = g_strdup_printf ("<span weight=\'light\'font_desc=\'%d\'><b>%s</b></span>",
+                             FontSzie,
+                             Word);
+        }
+        else
+        {
+            LableTypeBuf = g_strdup_printf ("<span weight=\'light\'font_desc=\'%d\'>%s</span>",
+                             FontSzie,
+                             Word);
+        }
     }
     else
     {

--- a/src/user-window.c
+++ b/src/user-window.c
@@ -91,7 +91,7 @@ static GtkWidget *set_unlock_button_tips (GtkWidget *button_lock)
     gtk_container_add(GTK_CONTAINER(box), image);
 
     label = gtk_label_new (NULL);
-    SetLableFontType(label, "black", 11, _("Some settings must be unlocked before they can be changed"), FALSE);
+    SetLableFontType(label, NULL, 11, _("Some settings must be unlocked before they can be changed"), FALSE);
     gtk_container_add(GTK_CONTAINER(box), label);
 
     gtk_popover_set_position (GTK_POPOVER (popover), GTK_POS_LEFT);
@@ -238,7 +238,7 @@ static void user_name_changed_cb (UserFace *face, UserWindow *win)
 
     name = user_face_get_real_name (face);
     act_user_set_real_name (win->priv->user, name);
-    SetLableFontType (win->priv->list_label, "black", 14, name, TRUE);
+    SetLableFontType (win->priv->list_label, NULL, 14, name, TRUE);
 }
 
 static void remove_user_cb (GtkWidget *widget, UserWindow *win)


### PR DESCRIPTION
Black text doesn't show up well in dark mode themes, so just let the theme choose the appropriate font color to use instead.

There are three places where the black text was used:

1) The authentication popover.

Before:
![BeforeLock](https://user-images.githubusercontent.com/2262453/198852348-e4d17bba-4aaa-4590-a1c3-0fcd50e870f6.png)

After:
![AfterLock](https://user-images.githubusercontent.com/2262453/198852460-29cbb208-b5ed-4008-a178-50a63670f978.png)


2) The groups window

Before:
![BeforeGroups](https://user-images.githubusercontent.com/2262453/198852346-a3764a33-a862-4577-b2a5-dacc7f414a8b.png)

After:
![AfterGroups](https://user-images.githubusercontent.com/2262453/198852462-3e8725b7-0cb4-4955-9060-c90ec8009435.png)



3) The callback for when the user's real name was changed (this looks to have been missed in fe00805194e9bd7649c98ba4b02aa7c3deb23785 when the original list was switched to use default colors).