### PR TITLE
user-avatar:  Fix double-free of image preview pixbuf

### DIFF
--- a/src/user-avatar.c
+++ b/src/user-avatar.c
@@ -90,7 +90,6 @@ static void thumbnail_preview (GtkFileChooser  *chooser,
         if (pixbuf != NULL)
         {
             gtk_image_set_from_pixbuf (GTK_IMAGE (preview), pixbuf);
-            g_object_unref (pixbuf);
         }
         else
         {


### PR DESCRIPTION
In the thumbnail_preview() function, the pixbuf of the preview of the selected image is marked as an "auto pointer".  That is, when the thumbnail_preview() function returns, the pixbuf reference count is decremented automatically, and freed if necessary.

However, if the pixbuf was actually used to show the user a preview of the selected image, then g_object_unref() was called on the pixbuf explicitly, then when the function returned, the pixbuf was unreferenced again by the auto-pointer mechanism.  This effectively pulls the rug out from under GTK+, which holds its own reference to the pixbuf to display it in the Preview pane in the file chooser dialog -- but the GTK+ reference is removed by the auto-pointer automatic free mechanism, and thus the pixbuf is deallocated before GTK+ has a chance to display the image.

On some systems (e.g. Gentoo i386 32-bit), this will produce lots of warning messages on the console, no thumbnail will be displayed, and there's about a 1 in 6 chance that the entire User Admin tool will crash.  On other systems (e.g. Ubuntu MATE x86-64 64-bit), the tool will crash as soon as the user selects to open a custom avatar image file and the file chooser pops up.  In either case, bad things happen.

This commit removes the explicit unreferencing of the pixbuf to avoid the crash.  It's not needed, anyway.

Just goes to show you that advanced labor-saving technologies are not a panacea, and that you can still shoot yourself in the foot!