### PR TITLE
Fix typo in logging function name

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -149,13 +149,13 @@ int main(int argc, char **argv)
 
     gtk_init (&argc, &argv);
 
-    mate_uesr_admin_log ("Info","mate-user-admin Version:%s",VERSION );
+    mate_user_admin_log ("Info","mate-user-admin Version:%s",VERSION );
     /* Program exit processing */
     atexit(ExitHook);
     /* Check whether the process has been started */
     if (ProcessRuning() == TRUE)
     {
-        mate_uesr_admin_log ("Info","The mate-user-admin process already exists");
+        mate_user_admin_log ("Info","The mate-user-admin process already exists");
         exit (0);
     }
 

--- a/src/user-admin.c
+++ b/src/user-admin.c
@@ -86,34 +86,34 @@ static gboolean user_manager_get_new_user_config (UserManager *dialog)
     Kconfig = g_key_file_new ();
     if (Kconfig == NULL)
     {
-        mate_uesr_admin_log ("Warning","g_key_file_new fail");
+        mate_user_admin_log ("Warning","g_key_file_new fail");
         return FALSE;
     }
     if (!g_key_file_load_from_file (Kconfig, NUCONFIG, G_KEY_FILE_NONE, &error))
     {
-        mate_uesr_admin_log ("Warning","Error loading key file: %s", error->message);
+        mate_user_admin_log ("Warning","Error loading key file: %s", error->message);
         goto EXIT;
     }
     ConfigGroups = g_key_file_get_groups (Kconfig, &Length);
     if (g_strv_length (ConfigGroups) <= 0)
     {
-        mate_uesr_admin_log ("Warning","key file format errors are not grouped");
+        mate_user_admin_log ("Warning","key file format errors are not grouped");
         goto EXIT;
     }
     if (g_key_file_has_key (Kconfig, KEYGROUPNAME, LANGKEY,&error) == FALSE)
     {
-        mate_uesr_admin_log ("Warning", "key file format errors %s", error->message);
+        mate_user_admin_log ("Warning", "key file format errors %s", error->message);
         goto EXIT;
     }
     Value = g_key_file_get_string(Kconfig,KEYGROUPNAME,LANGKEY,&error);
     if(Value == NULL)
     {
-        mate_uesr_admin_log ("Warning","key file format errors %s",error->message);
+        mate_user_admin_log ("Warning","key file format errors %s",error->message);
         goto EXIT;
     }
     if(mate_get_language_from_locale(Value,NULL) == NULL)
     {
-        mate_uesr_admin_log ("Warning", "key file language format errors Language unavailability");
+        mate_user_admin_log ("Warning", "key file language format errors Language unavailability");
         goto EXIT;
     }
     dialog->priv->user_lang = g_strdup (Value);
@@ -121,7 +121,7 @@ static gboolean user_manager_get_new_user_config (UserManager *dialog)
     Type = g_key_file_get_boolean (Kconfig, KEYGROUPNAME, TYPEKEY, &error);
     if(Type == FALSE && error != NULL)
     {
-        mate_uesr_admin_log ("Warning", "key file user type format errors %s", error->message);
+        mate_user_admin_log ("Warning", "key file user type format errors %s", error->message);
         goto EXIT;
     }
     dialog->priv->user_type = Type;
@@ -129,7 +129,7 @@ static gboolean user_manager_get_new_user_config (UserManager *dialog)
     admin_groups = g_key_file_get_string_list (Kconfig, KEYGROUPNAME, ADMINGROUPKEY, &Length, &error);
     if (admin_groups == NULL)
     {
-        mate_uesr_admin_log ("Info", "key file No default add group is set for admin new users");
+        mate_user_admin_log ("Info", "key file No default add group is set for admin new users");
         g_key_file_free (Kconfig);
         return TRUE;
     }
@@ -138,7 +138,7 @@ static gboolean user_manager_get_new_user_config (UserManager *dialog)
     stand_groups = g_key_file_get_string_list (Kconfig, KEYGROUPNAME, STANDGROUPKEY, &Length, &error);
     if (stand_groups == NULL)
     {
-        mate_uesr_admin_log ("Info", "key file No default add group is set for stand new users");
+        mate_user_admin_log ("Info", "key file No default add group is set for stand new users");
         g_key_file_free (Kconfig);
         return TRUE;
     }
@@ -409,7 +409,7 @@ static const gchar *GetNewUserLang (UserManager *dialog)
 {
     if(dialog->priv->user_lang != NULL)
     {
-        mate_uesr_admin_log ("Debug","nuLang = %s", dialog->priv->user_lang);
+        mate_user_admin_log ("Debug","nuLang = %s", dialog->priv->user_lang);
         return dialog->priv->user_lang;
     }
     return "en_US.utf8";
@@ -432,18 +432,18 @@ static void add_user_to_group (const char *name, char **groups)
             {
                 if (g_utf8_strchr (groups[i],-1,' ') != NULL)
                 {
-                    mate_uesr_admin_log ("Warning","Configuration file error,Please delete the extra space keys");
+                    mate_user_admin_log ("Warning","Configuration file error,Please delete the extra space keys");
                 }
-                mate_uesr_admin_log ("Warning","Configuration file error, no group %s",groups[i]);
+                mate_user_admin_log ("Warning","Configuration file error, no group %s",groups[i]);
                 continue;
             }
             gas = gas_group_manager_get_group (manage,groups[i]);
             if(gas == NULL)
             {
-                mate_uesr_admin_log ("Warning","Configuration file error, no group %s",groups[i]);
+                mate_user_admin_log ("Warning","Configuration file error, no group %s",groups[i]);
                 continue;
             }
-            mate_uesr_admin_log ("Debug","group name %s",groups[i]);
+            mate_user_admin_log ("Debug","group name %s",groups[i]);
             gas_group_add_user_group (gas, name);
         }
 
@@ -478,7 +478,7 @@ static void set_new_user_base_info (ActUser         *user,
         act_user_set_password (user,Password, "");
     }
     un = gtk_entry_get_text (GTK_ENTRY (dialog->priv->name_entry));
-    mate_uesr_admin_log ("Debug","New user: %s lang %s", act_user_get_user_name (user), NewUserLang);
+    mate_user_admin_log ("Debug","New user: %s lang %s", act_user_get_user_name (user), NewUserLang);
 
     if (dialog->priv->user_type == 0)
         add_user_to_group (un, dialog->priv->stand_user_groups);
@@ -503,7 +503,7 @@ static void CreateUserDone (ActUserManager  *Manager,
         close_dialog (GTK_WIDGET (dialog));
         return;
     }
-    mate_uesr_admin_log ("Debug","Created user: %s success", act_user_get_user_name (user));
+    mate_user_admin_log ("Debug","Created user: %s success", act_user_get_user_name (user));
     if (act_user_is_loaded (user))
         set_new_user_base_info (user, NULL, dialog);
     else
@@ -542,7 +542,7 @@ static void CreateLocalNewUser(UserManager *dialog)
         dialog->priv->name_time_id = 0;
     }
     Manager = act_user_manager_get_default ();
-    mate_uesr_admin_log ("Debug","username %s realname %s",
+    mate_user_admin_log ("Debug","username %s realname %s",
                          un, rn);
     act_user_manager_create_user_async (Manager,
                                         un,
@@ -825,7 +825,7 @@ static void GetPermission (GObject      *source_object,
     }
     else if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
     {
-        mate_uesr_admin_log ("Warning","Failed to acquire permission: %s", error->message);
+        mate_user_admin_log ("Warning","Failed to acquire permission: %s", error->message);
     }
 
     g_clear_error (&error);

--- a/src/user-avatar.c
+++ b/src/user-avatar.c
@@ -485,7 +485,7 @@ create_avatar_menus (UserAvatar *avatar)
     ret = add_list_faces_file (avatar->priv->faces);
     if(!ret)
     {
-        mate_uesr_admin_log("Warning","mate-user-admin There is no address to store photos");
+        mate_user_admin_log("Warning","mate-user-admin There is no address to store photos");
         MessageReport(_("Avatar list"),
                       _("There is no address to store photos"),
                       WARING);

--- a/src/user-face.c
+++ b/src/user-face.c
@@ -199,7 +199,7 @@ void user_face_fill (UserFace *face, ActUser *user)
     pb = gdk_pixbuf_new_from_file (GetUserIcon (user), &error);
     if (pb == NULL)
     {
-        mate_uesr_admin_log ("Warning","mate-user-admin user icon %s", error->message);
+        mate_user_admin_log ("Warning","mate-user-admin user icon %s", error->message);
         g_error_free (error);
     }
     pb2 = gdk_pixbuf_scale_simple (pb, 96, 96, GDK_INTERP_BILINEAR);

--- a/src/user-group-window.c
+++ b/src/user-group-window.c
@@ -892,7 +892,7 @@ void user_group_window_init (UserGroupWindow *group_window)
     group_window->priv->NewGroupUsers = NULL;
     if (group_window->priv->permission == NULL)
     {
-        mate_uesr_admin_log ("Warning","Cannot create '%s' permission: %s", USER_GROUP_PERMISSION, error->message);
+        mate_user_admin_log ("Warning","Cannot create '%s' permission: %s", USER_GROUP_PERMISSION, error->message);
         g_error_free (error);
     }
     button_lock = gtk_lock_button_new (group_window->priv->permission);

--- a/src/user-info.c
+++ b/src/user-info.c
@@ -203,12 +203,12 @@ GSList *get_user_info_list (ActUserManager *manager)
     if (user_count <= 0)
     {
         g_slist_free (list);
-        mate_uesr_admin_log ("Error","mate-user-admin No available users");
+        mate_user_admin_log ("Error","mate-user-admin No available users");
         MessageReport (_("Get User Info"), _("user count is 0"), ERROR);
 
         return NULL;
     }
-    mate_uesr_admin_log ("Info","mate-user-admin user %d", user_count);
+    mate_user_admin_log ("Info","mate-user-admin user %d", user_count);
 
     /*user sort */
     list = g_slist_sort (list, (GCompareFunc)SortUsers);

--- a/src/user-language.c
+++ b/src/user-language.c
@@ -507,7 +507,7 @@ add_all_languages (UserLanguage *chooser)
 
     locale_ids = mate_get_all_locales ();
     if(g_strv_length(locale_ids) == 0)
-        mate_uesr_admin_log("Warning","mate-user-admin get_all_locales ->0 No available language");
+        mate_user_admin_log("Warning","mate-user-admin get_all_locales ->0 No available language");
     initial = create_language_hash_table ();
 
     add_languages (chooser, locale_ids, initial);

--- a/src/user-share.c
+++ b/src/user-share.c
@@ -73,7 +73,7 @@ GdkPixbuf *GetRoundPixbuf (GdkPixbuf *Spixbuf)
     return Dpixbuf;
 }
 /*Record error information to log file*/
-void mate_uesr_admin_log(const char *level,const char *message,...)
+void mate_user_admin_log(const char *level,const char *message,...)
 {
     int     fd;
     va_list args;

--- a/src/user-share.h
+++ b/src/user-share.h
@@ -48,7 +48,7 @@
 #define  ADMIN     1
 
 
-void         mate_uesr_admin_log   (const char  *level,
+void         mate_user_admin_log   (const char  *level,
                                     const char  *message,
                                     ...);
 

--- a/src/user-window.c
+++ b/src/user-window.c
@@ -64,7 +64,7 @@ static void user_window_update (UserWindow *win,
     user_face_update (win->priv->face, GetUserIcon (user), GetRealName (user));
     user_base_update_user_info (win->priv->base, user);
 
-    mate_uesr_admin_log("Info","mate-user-admin Current user name %s",GetRealName(user));
+    mate_user_admin_log("Info","mate-user-admin Current user name %s",GetRealName(user));
 
     if(self_selected == 0)
     {
@@ -163,7 +163,7 @@ static void user_window_set_permission (UserWindow *win)
     }
     else
     {
-        mate_uesr_admin_log ("Warning","Cannot create '%s' permission: %s", USER_ADMIN_PERMISSION, error->message);
+        mate_user_admin_log ("Warning","Cannot create '%s' permission: %s", USER_ADMIN_PERMISSION, error->message);
         g_error_free (error);
     }
 }


### PR DESCRIPTION
This fixes the "user"->"uesr" typo in the name of the logging function